### PR TITLE
Fix environment variable name for Heroku deployment

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -7,7 +7,7 @@ workflows:
     jobs:
       # Deployment to staging occurs on the main branch
       - heroku/deploy-via-git:
-          api-key: $STAGING_HEROKU_API_KEY
+          api-key: STAGING_HEROKU_API_KEY
           app-name: $STAGING_HEROKU_APP_NAME
           filters:
             branches:


### PR DESCRIPTION
### Administrative Info
Monday Board ID: 853648344
Make sure your branch name conforms to: `<feature/staging/hotfix/...>/[username]/[Monday Item ID]-[3-4 word description separated by dashes]`. Otherwise, please rename your branch and create a new PR.

### Changes
What changes did you make?
- Fix `api-key` to be of type env_var_name instead of string.

### Testing
How did you confirm your changes worked? 
- n/a
